### PR TITLE
Fixing up github watchers count

### DIFF
--- a/pages/project/_path.vue
+++ b/pages/project/_path.vue
@@ -27,7 +27,7 @@
           <div class="stats-details">
             <div>
               <WatchIcon v-bind:w="18" v-bind:h="18" />
-              <p>{{ project.watchers_count }}</p>
+              <p>{{ project.subscribers_count }}</p>
             </div>
             <p>watchers</p>
           </div>


### PR DESCRIPTION
Github watchers match stargazers for legacy support. Watcher count is found as subscriber_count on the API.