### PR TITLE
Delete deprecated option

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,5 @@
 
 export default {
-  mode: 'universal',
   /*
   ** Headers of the page
   */


### PR DESCRIPTION
Prevent this warning from popping up in the logs:
 `WARN  mode option is deprecated. You can safely remove it from nuxt.config`